### PR TITLE
Add function to update token metadata with parametrized seller fee

### DIFF
--- a/api/metaplex_api.py
+++ b/api/metaplex_api.py
@@ -90,11 +90,11 @@ class MetaplexAPI():
         # except:
         #     return json.dumps({"status": 400})
         
-    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
+    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share,fee, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
             """
             Updates the json metadata for a given mint token id.
             """
-            tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share)
+            tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, fee)
             resp = execute(
                 api_endpoint,
                 tx,

--- a/api/metaplex_api.py
+++ b/api/metaplex_api.py
@@ -2,7 +2,7 @@ import json
 from cryptography.fernet import Fernet
 import base58
 from solana.account import Account 
-from metaplex.transactions import deploy, topup, mint, send, burn
+from metaplex.transactions import deploy, topup, mint, send, burn, update_token_metadata
 from utils.execution_engine import execute
 
 class MetaplexAPI():
@@ -89,6 +89,25 @@ class MetaplexAPI():
         return json.dumps(resp)
         # except:
         #     return json.dumps({"status": 400})
+        
+    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
+            """
+            Updates the json metadata for a given mint token id.
+            """
+            tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share)
+            resp = execute(
+                api_endpoint,
+                tx,
+                signers,
+                max_retries=max_retries,
+                skip_confirmation=skip_confirmation,
+                max_timeout=max_timeout,
+                target=target,
+                finalized=finalized,
+            )
+            resp["status"] = 200
+            return json.dumps(resp)
+
 
     def send(self, api_endpoint, contract_key, sender_key, dest_key, encrypted_private_key, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True):
         """

--- a/api/metaplex_api.py
+++ b/api/metaplex_api.py
@@ -1,9 +1,10 @@
 import json
 from cryptography.fernet import Fernet
 import base58
-from solana.account import Account 
+from solana.account import Account
 from metaplex.transactions import deploy, topup, mint, send, burn, update_token_metadata
 from utils.execution_engine import execute
+
 
 class MetaplexAPI():
 
@@ -16,7 +17,7 @@ class MetaplexAPI():
     def wallet(self):
         """ Generate a wallet and return the address and private key. """
         account = Account()
-        pub_key = account.public_key() 
+        pub_key = account.public_key()
         private_key = list(account.secret_key()[:32])
         return json.dumps(
             {
@@ -31,7 +32,8 @@ class MetaplexAPI():
         Returns status code of success or fail, the contract address, and the native transaction data.
         """
         try:
-            tx, signers, contract = deploy(api_endpoint, self.account, name, symbol)
+            tx, signers, contract = deploy(
+                api_endpoint, self.account, name, symbol)
             print(contract)
             resp = execute(
                 api_endpoint,
@@ -70,11 +72,12 @@ class MetaplexAPI():
         except:
             return json.dumps({"status": 400})
 
-    def mint(self, api_endpoint, contract_key, dest_key, link, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
+    def mint(self, api_endpoint, contract_key, dest_key, link, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1):
         """
         Mints an NFT to an account, updates the metadata and creates a master edition
         """
-        tx, signers = mint(api_endpoint, self.account, contract_key, dest_key, link, supply=supply)
+        tx, signers = mint(api_endpoint, self.account,
+                           contract_key, dest_key, link, supply=supply)
         resp = execute(
             api_endpoint,
             tx,
@@ -89,25 +92,25 @@ class MetaplexAPI():
         return json.dumps(resp)
         # except:
         #     return json.dumps({"status": 400})
-        
-    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share,fee, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
-            """
-            Updates the json metadata for a given mint token id.
-            """
-            tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, fee)
-            resp = execute(
-                api_endpoint,
-                tx,
-                signers,
-                max_retries=max_retries,
-                skip_confirmation=skip_confirmation,
-                max_timeout=max_timeout,
-                target=target,
-                finalized=finalized,
-            )
-            resp["status"] = 200
-            return json.dumps(resp)
 
+    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, fee, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1):
+        """
+        Updates the json metadata for a given mint token id.
+        """
+        tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id,
+                                            link,  data, creators_addresses, creators_verified, creators_share, fee)
+        resp = execute(
+            api_endpoint,
+            tx,
+            signers,
+            max_retries=max_retries,
+            skip_confirmation=skip_confirmation,
+            max_timeout=max_timeout,
+            target=target,
+            finalized=finalized,
+        )
+        resp["status"] = 200
+        return json.dumps(resp)
 
     def send(self, api_endpoint, contract_key, sender_key, dest_key, encrypted_private_key, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True):
         """
@@ -117,7 +120,8 @@ class MetaplexAPI():
         """
         try:
             private_key = list(self.cipher.decrypt(encrypted_private_key))
-            tx, signers = send(api_endpoint, self.account, contract_key, sender_key, dest_key, private_key)
+            tx, signers = send(api_endpoint, self.account,
+                               contract_key, sender_key, dest_key, private_key)
             resp = execute(
                 api_endpoint,
                 tx,
@@ -141,7 +145,8 @@ class MetaplexAPI():
         """
         try:
             private_key = list(self.cipher.decrypt(encrypted_private_key))
-            tx, signers = burn(api_endpoint, contract_key, owner_key, private_key)
+            tx, signers = burn(api_endpoint, contract_key,
+                               owner_key, private_key)
             resp = execute(
                 api_endpoint,
                 tx,

--- a/metaplex/metadata.py
+++ b/metaplex/metadata.py
@@ -13,15 +13,20 @@ MAX_SYMBOL_LENGTH = 10
 MAX_URI_LENGTH = 200
 MAX_CREATOR_LENGTH = 34
 MAX_CREATOR_LIMIT = 5
+
+
 class InstructionType(IntEnum):
     CREATE_METADATA = 0
     UPDATE_METADATA = 1
 
+
 METADATA_PROGRAM_ID = PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s')
 SYSTEM_PROGRAM_ID = PublicKey('11111111111111111111111111111111')
-SYSVAR_RENT_PUBKEY = PublicKey('SysvarRent111111111111111111111111111111111') 
-ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL')
+SYSVAR_RENT_PUBKEY = PublicKey('SysvarRent111111111111111111111111111111111')
+ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = PublicKey(
+    'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL')
 TOKEN_PROGRAM_ID = PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+
 
 def get_metadata_account(mint_key):
     return PublicKey.find_program_address(
@@ -29,30 +34,39 @@ def get_metadata_account(mint_key):
         METADATA_PROGRAM_ID
     )[0]
 
+
 def get_edition(mint_key):
     return PublicKey.find_program_address(
-        [b'metadata', bytes(METADATA_PROGRAM_ID), bytes(PublicKey(mint_key)), b"edition"],
+        [b'metadata', bytes(METADATA_PROGRAM_ID), bytes(
+            PublicKey(mint_key)), b"edition"],
         METADATA_PROGRAM_ID
     )[0]
+
 
 def create_associated_token_account_instruction(associated_token_account, payer, wallet_address, token_mint_address):
     keys = [
         AccountMeta(pubkey=payer, is_signer=True, is_writable=True),
-        AccountMeta(pubkey=associated_token_account, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=associated_token_account,
+                    is_signer=False, is_writable=True),
         AccountMeta(pubkey=wallet_address, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=token_mint_address, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=SYSTEM_PROGRAM_ID, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=SYSVAR_RENT_PUBKEY, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=token_mint_address,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=SYSTEM_PROGRAM_ID,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=TOKEN_PROGRAM_ID,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=SYSVAR_RENT_PUBKEY,
+                    is_signer=False, is_writable=False),
     ]
     return TransactionInstruction(keys=keys, program_id=ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID)
+
 
 def _get_data_buffer(name, symbol, uri, creators, fee, verified=None, share=None):
     if isinstance(share, list):
         assert(len(share) == len(creators))
     if isinstance(verified, list):
         assert(len(verified) == len(creators))
-    args =  [
+    args = [
         len(name),
         *list(name.encode()),
         len(symbol),
@@ -61,8 +75,8 @@ def _get_data_buffer(name, symbol, uri, creators, fee, verified=None, share=None
         *list(uri.encode()),
         fee,
     ]
-    print(args)
-    byte_fmt = "<" 
+
+    byte_fmt = "<"
     byte_fmt += "I" + "B"*len(name)
     byte_fmt += "I" + "B"*len(symbol)
     byte_fmt += "I" + "B"*len(uri)
@@ -72,8 +86,8 @@ def _get_data_buffer(name, symbol, uri, creators, fee, verified=None, share=None
         args.append(1)
         byte_fmt += "I"
         args.append(len(creators))
-        for i, creator in enumerate(creators): 
-            byte_fmt +=  "B"*32 + "B" + "B"
+        for i, creator in enumerate(creators):
+            byte_fmt += "B"*32 + "B" + "B"
             args.extend(list(base58.b58decode(creator)))
             if isinstance(verified, list):
                 args.append(verified[i])
@@ -84,10 +98,11 @@ def _get_data_buffer(name, symbol, uri, creators, fee, verified=None, share=None
             else:
                 args.append(100)
     else:
-        args.append(0) 
+        args.append(0)
     buffer = struct.pack(byte_fmt, *args)
     return buffer
-    
+
+
 def create_metadata_instruction_data(name, symbol, creators, fee):
     _data = _get_data_buffer(name, symbol, " "*64, creators, fee)
     metadata_args_layout = cStruct(
@@ -106,41 +121,50 @@ def create_metadata_instruction_data(name, symbol, creators, fee):
         )
     )
 
+
 def create_metadata_instruction(data, update_authority, mint_key, mint_authority_key, payer):
     metadata_account = get_metadata_account(mint_key)
     keys = [
-        AccountMeta(pubkey=metadata_account, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=metadata_account,
+                    is_signer=False, is_writable=True),
         AccountMeta(pubkey=mint_key, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=mint_authority_key, is_signer=True, is_writable=False),
+        AccountMeta(pubkey=mint_authority_key,
+                    is_signer=True, is_writable=False),
         AccountMeta(pubkey=payer, is_signer=True, is_writable=False),
-        AccountMeta(pubkey=update_authority, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=SYSTEM_PROGRAM_ID, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=SYSVAR_RENT_PUBKEY, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=update_authority,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=SYSTEM_PROGRAM_ID,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=SYSVAR_RENT_PUBKEY,
+                    is_signer=False, is_writable=False),
     ]
     return TransactionInstruction(keys=keys, program_id=METADATA_PROGRAM_ID, data=data)
+
 
 def unpack_metadata_account(data):
     assert(data[0] == 4)
     i = 1
-    source_account = base58.b58encode(bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
+    source_account = base58.b58encode(
+        bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
     i += 32
-    mint_account = base58.b58encode(bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
+    mint_account = base58.b58encode(
+        bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
     i += 32
     name_len = struct.unpack('<I', data[i:i+4])[0]
     i += 4
     name = struct.unpack('<' + "B"*name_len, data[i:i+name_len])
     i += name_len
     symbol_len = struct.unpack('<I', data[i:i+4])[0]
-    i += 4 
+    i += 4
     symbol = struct.unpack('<' + "B"*symbol_len, data[i:i+symbol_len])
     i += symbol_len
     uri_len = struct.unpack('<I', data[i:i+4])[0]
-    i += 4 
+    i += 4
     uri = struct.unpack('<' + "B"*uri_len, data[i:i+uri_len])
     i += uri_len
     fee = struct.unpack('<h', data[i:i+2])[0]
     i += 2
-    has_creator = data[i] 
+    has_creator = data[i]
     i += 1
     creators = []
     verified = []
@@ -149,7 +173,8 @@ def unpack_metadata_account(data):
         creator_len = struct.unpack('<I', data[i:i+4])[0]
         i += 4
         for _ in range(creator_len):
-            creator = base58.b58encode(bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
+            creator = base58.b58encode(
+                bytes(struct.unpack('<' + "B"*32, data[i:i+32])))
             creators.append(creator)
             i += 32
             verified.append(data[i])
@@ -176,14 +201,18 @@ def unpack_metadata_account(data):
     }
     return metadata
 
+
 def get_metadata(client, mint_key):
     metadata_account = get_metadata_account(mint_key)
-    data = base64.b64decode(client.get_account_info(metadata_account)['result']['value']['data'][0])
+    data = base64.b64decode(client.get_account_info(
+        metadata_account)['result']['value']['data'][0])
     metadata = unpack_metadata_account(data)
     return metadata
 
+
 def update_metadata_instruction_data(name, symbol, uri, creators, fee, verified, share):
-    _data = bytes([1]) + _get_data_buffer(name, symbol, uri, creators, fee, verified, share) + bytes([0, 0])
+    _data = bytes([1]) + _get_data_buffer(name, symbol, uri,
+                                          creators, fee, verified, share) + bytes([0, 0])
     instruction_layout = cStruct(
         "instruction_type" / Int8ul,
         "args" / Bytes(len(_data)),
@@ -195,13 +224,17 @@ def update_metadata_instruction_data(name, symbol, uri, creators, fee, verified,
         )
     )
 
+
 def update_metadata_instruction(data, update_authority, mint_key):
     metadata_account = get_metadata_account(mint_key)
     keys = [
-        AccountMeta(pubkey=metadata_account, is_signer=False, is_writable=True),
-        AccountMeta(pubkey=update_authority, is_signer=True, is_writable=False),
+        AccountMeta(pubkey=metadata_account,
+                    is_signer=False, is_writable=True),
+        AccountMeta(pubkey=update_authority,
+                    is_signer=True, is_writable=False),
     ]
     return TransactionInstruction(keys=keys, program_id=METADATA_PROGRAM_ID, data=data)
+
 
 def create_master_edition_instruction(
     mint: PublicKey,
@@ -219,13 +252,18 @@ def create_master_edition_instruction(
     keys = [
         AccountMeta(pubkey=edition_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=mint, is_signer=False, is_writable=True),
-        AccountMeta(pubkey=update_authority, is_signer=True, is_writable=False),
+        AccountMeta(pubkey=update_authority,
+                    is_signer=True, is_writable=False),
         AccountMeta(pubkey=mint_authority, is_signer=True, is_writable=False),
         AccountMeta(pubkey=payer, is_signer=True, is_writable=False),
-        AccountMeta(pubkey=metadata_account, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=PublicKey(TOKEN_PROGRAM_ID), is_signer=False, is_writable=False),
-        AccountMeta(pubkey=PublicKey(SYSTEM_PROGRAM_ID), is_signer=False, is_writable=False),
-        AccountMeta(pubkey=PublicKey(SYSVAR_RENT_PUBKEY), is_signer=False, is_writable=False),
+        AccountMeta(pubkey=metadata_account,
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=PublicKey(TOKEN_PROGRAM_ID),
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=PublicKey(SYSTEM_PROGRAM_ID),
+                    is_signer=False, is_writable=False),
+        AccountMeta(pubkey=PublicKey(SYSVAR_RENT_PUBKEY),
+                    is_signer=False, is_writable=False),
     ]
     return TransactionInstruction(
         keys=keys,

--- a/metaplex/metadata.py
+++ b/metaplex/metadata.py
@@ -47,7 +47,7 @@ def create_associated_token_account_instruction(associated_token_account, payer,
     ]
     return TransactionInstruction(keys=keys, program_id=ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID)
 
-def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
+def _get_data_buffer(name, symbol, uri, creators, fee, verified=None, share=None):
     if isinstance(share, list):
         assert(len(share) == len(creators))
     if isinstance(verified, list):
@@ -59,7 +59,7 @@ def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
         *list(symbol.encode()),
         len(uri),
         *list(uri.encode()),
-        500,
+        fee,
     ]
     print(args)
     byte_fmt = "<" 
@@ -88,8 +88,8 @@ def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
     buffer = struct.pack(byte_fmt, *args)
     return buffer
     
-def create_metadata_instruction_data(name, symbol, creators):
-    _data = _get_data_buffer(name, symbol, " "*64, creators)
+def create_metadata_instruction_data(name, symbol, creators, fee):
+    _data = _get_data_buffer(name, symbol, " "*64, creators, fee)
     metadata_args_layout = cStruct(
         "data" / Bytes(len(_data)),
         "is_mutable" / Flag,
@@ -182,8 +182,8 @@ def get_metadata(client, mint_key):
     metadata = unpack_metadata_account(data)
     return metadata
 
-def update_metadata_instruction_data(name, symbol, uri, creators, verified, share):
-    _data = bytes([1]) + _get_data_buffer(name, symbol, uri, creators, verified, share) + bytes([0, 0])
+def update_metadata_instruction_data(name, symbol, uri, creators, fee, verified, share):
+    _data = bytes([1]) + _get_data_buffer(name, symbol, uri, creators, fee, verified, share) + bytes([0, 0])
     instruction_layout = cStruct(
         "instruction_type" / Int8ul,
         "args" / Bytes(len(_data)),

--- a/metaplex/metadata.py
+++ b/metaplex/metadata.py
@@ -59,8 +59,9 @@ def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
         *list(symbol.encode()),
         len(uri),
         *list(uri.encode()),
-        0,
+        500,
     ]
+    print(args)
     byte_fmt = "<" 
     byte_fmt += "I" + "B"*len(name)
     byte_fmt += "I" + "B"*len(symbol)

--- a/metaplex/transactions.py
+++ b/metaplex/transactions.py
@@ -107,7 +107,7 @@ def topup(api_endpoint, sender_account, to, amount=None):
     tx = tx.add(transfer_ix)
     return tx, signers
 
-def update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, creators_addresses, creators_verified, creators_share):
+def update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, creators_addresses, creators_verified, creators_share, fee):
     """
     Updates the json metadata for a given mint token id.
     """
@@ -120,6 +120,7 @@ def update_token_metadata(api_endpoint, source_account, mint_token_id, link, dat
         data['symbol'],
         link,
         creators_addresses,
+        fee,
         creators_verified,
         creators_share,
     )
@@ -188,6 +189,7 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
         metadata['data']['symbol'],
         link,
         metadata['data']['creators'],
+        metadata['data']['fee'],
         metadata['data']['verified'],
         metadata['data']['share'],
     )

--- a/metaplex/transactions.py
+++ b/metaplex/transactions.py
@@ -1,10 +1,10 @@
 import json
 import base64
-from solana.publickey import PublicKey 
+from solana.publickey import PublicKey
 from solana.transaction import Transaction
-from solana.account import Account 
+from solana.account import Account
 from solana.rpc.api import Client
-from solana.system_program import transfer, TransferParams, create_account, CreateAccountParams 
+from solana.system_program import transfer, TransferParams, create_account, CreateAccountParams
 from spl.token._layouts import MINT_LAYOUT, ACCOUNT_LAYOUT
 from spl.token.instructions import (
     get_associated_token_address, mint_to, MintToParams,
@@ -15,7 +15,7 @@ from spl.token.instructions import (
 from metaplex.metadata import (
     create_associated_token_account_instruction,
     create_master_edition_instruction,
-    create_metadata_instruction_data, 
+    create_metadata_instruction_data,
     create_metadata_instruction,
     get_metadata,
     update_metadata_instruction_data,
@@ -30,15 +30,16 @@ def deploy(api_endpoint, source_account, name, symbol):
     client = Client(api_endpoint)
     # List non-derived accounts
     mint_account = Account()
-    token_account = TOKEN_PROGRAM_ID 
+    token_account = TOKEN_PROGRAM_ID
     # List signers
     signers = [source_account, mint_account]
     # Start transaction
     tx = Transaction()
     # Get the minimum rent balance for a mint account
-    min_rent_reseponse = client.get_minimum_balance_for_rent_exemption(MINT_LAYOUT.sizeof()) # type: ignore
+    min_rent_reseponse = client.get_minimum_balance_for_rent_exemption(
+        MINT_LAYOUT.sizeof())  # type: ignore
     lamports = min_rent_reseponse["result"]
-    # Generate Mint 
+    # Generate Mint
     create_mint_account_ix = create_account(
         CreateAccountParams(
             from_pubkey=source_account.public_key(),
@@ -61,7 +62,8 @@ def deploy(api_endpoint, source_account, name, symbol):
     tx = tx.add(initialize_mint_ix)
     # Create Token Metadata
     create_metadata_ix = create_metadata_instruction(
-        data=create_metadata_instruction_data(name, symbol, [str(source_account.public_key())]),
+        data=create_metadata_instruction_data(
+            name, symbol, [str(source_account.public_key())]),
         update_authority=source_account.public_key(),
         mint_key=mint_account.public_key(),
         mint_authority_key=source_account.public_key(),
@@ -69,12 +71,12 @@ def deploy(api_endpoint, source_account, name, symbol):
     )
     tx = tx.add(create_metadata_ix)
     return tx, signers, str(mint_account.public_key())
-    
+
 
 def wallet():
     """ Generate a wallet and return the address and private key. """
     account = Account()
-    pub_key = account.public_key() 
+    pub_key = account.public_key()
     private_key = list(account.secret_key()[:32])
     return json.dumps(
         {
@@ -90,22 +92,25 @@ def topup(api_endpoint, sender_account, to, amount=None):
     """
     # Connect to the api_endpoint
     client = Client(api_endpoint)
-    # List accounts 
+    # List accounts
     dest_account = PublicKey(to)
     # List signers
     signers = [sender_account]
     # Start transaction
     tx = Transaction()
-    # Determine the amount to send 
+    # Determine the amount to send
     if amount is None:
-        min_rent_reseponse = client.get_minimum_balance_for_rent_exemption(ACCOUNT_LAYOUT.sizeof())
+        min_rent_reseponse = client.get_minimum_balance_for_rent_exemption(
+            ACCOUNT_LAYOUT.sizeof())
         lamports = min_rent_reseponse["result"]
     else:
         lamports = int(amount)
     # Generate transaction
-    transfer_ix = transfer(TransferParams(from_pubkey=sender_account.public_key(), to_pubkey=dest_account, lamports=lamports))
+    transfer_ix = transfer(TransferParams(
+        from_pubkey=sender_account.public_key(), to_pubkey=dest_account, lamports=lamports))
     tx = tx.add(transfer_ix)
     return tx, signers
+
 
 def update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, creators_addresses, creators_verified, creators_share, fee):
     """
@@ -129,7 +134,7 @@ def update_token_metadata(api_endpoint, source_account, mint_token_id, link, dat
         source_account.public_key(),
         mint_account,
     )
-    tx = tx.add(update_metadata_ix) 
+    tx = tx.add(update_metadata_ix)
     return tx, signers
 
 
@@ -155,22 +160,25 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
     # Start transaction
     tx = Transaction()
     # Create Associated Token Account
-    associated_token_account = get_associated_token_address(user_account, mint_account)
-    associated_token_account_info = client.get_account_info(associated_token_account)
+    associated_token_account = get_associated_token_address(
+        user_account, mint_account)
+    associated_token_account_info = client.get_account_info(
+        associated_token_account)
     # Check if PDA is initialized. If not, create the account
     account_info = associated_token_account_info['result']['value']
-    if account_info is not None: 
-        account_state = ACCOUNT_LAYOUT.parse(base64.b64decode(account_info['data'][0])).state
+    if account_info is not None:
+        account_state = ACCOUNT_LAYOUT.parse(
+            base64.b64decode(account_info['data'][0])).state
     else:
         account_state = 0
     if account_state == 0:
         associated_token_account_ix = create_associated_token_account_instruction(
             associated_token_account=associated_token_account,
-            payer=source_account.public_key(), # signer
+            payer=source_account.public_key(),  # signer
             wallet_address=user_account,
             token_mint_address=mint_account,
         )
-        tx = tx.add(associated_token_account_ix)  
+        tx = tx.add(associated_token_account_ix)
     # Mint NFT to the newly create associated token account
     mint_to_ix = mint_to(
         MintToParams(
@@ -182,7 +190,7 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
             signers=[source_account.public_key()],
         )
     )
-    tx = tx.add(mint_to_ix) 
+    tx = tx.add(mint_to_ix)
     metadata = get_metadata(client, mint_account)
     update_metadata_data = update_metadata_instruction_data(
         metadata['data']['name'],
@@ -198,7 +206,7 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
         source_account.public_key(),
         mint_account,
     )
-    tx = tx.add(update_metadata_ix) 
+    tx = tx.add(update_metadata_ix)
     create_master_edition_ix = create_master_edition_instruction(
         mint=mint_account,
         update_authority=source_account.public_key(),
@@ -206,7 +214,7 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
         payer=source_account.public_key(),
         supply=supply,
     )
-    tx = tx.add(create_master_edition_ix) 
+    tx = tx.add(create_master_edition_ix)
     return tx, signers
 
 
@@ -219,8 +227,8 @@ def send(api_endpoint, source_account, contract_key, sender_key, dest_key, priva
     # Initialize Client
     client = Client(api_endpoint)
     # List non-derived accounts
-    owner_account = Account(private_key) # Owner of contract 
-    sender_account = PublicKey(sender_key) # Public key of `owner_account`
+    owner_account = Account(private_key)  # Owner of contract
+    sender_account = PublicKey(sender_key)  # Public key of `owner_account`
     token_account = TOKEN_PROGRAM_ID
     mint_account = PublicKey(contract_key)
     dest_account = PublicKey(dest_key)
@@ -229,25 +237,29 @@ def send(api_endpoint, source_account, contract_key, sender_key, dest_key, priva
     # Start transaction
     tx = Transaction()
     # Find PDA for sender
-    token_pda_address = get_associated_token_address(sender_account, mint_account)
-    if client.get_account_info(token_pda_address)['result']['value'] is None: 
+    token_pda_address = get_associated_token_address(
+        sender_account, mint_account)
+    if client.get_account_info(token_pda_address)['result']['value'] is None:
         raise Exception
     # Check if PDA is initialized for receiver. If not, create the account
-    associated_token_account = get_associated_token_address(dest_account, mint_account)
-    associated_token_account_info = client.get_account_info(associated_token_account)
+    associated_token_account = get_associated_token_address(
+        dest_account, mint_account)
+    associated_token_account_info = client.get_account_info(
+        associated_token_account)
     account_info = associated_token_account_info['result']['value']
-    if account_info is not None: 
-        account_state = ACCOUNT_LAYOUT.parse(base64.b64decode(account_info['data'][0])).state
+    if account_info is not None:
+        account_state = ACCOUNT_LAYOUT.parse(
+            base64.b64decode(account_info['data'][0])).state
     else:
         account_state = 0
     if account_state == 0:
         associated_token_account_ix = create_associated_token_account_instruction(
             associated_token_account=associated_token_account,
-            payer=source_account.public_key(), # signer
+            payer=source_account.public_key(),  # signer
             wallet_address=dest_account,
             token_mint_address=mint_account,
         )
-        tx = tx.add(associated_token_account_ix)        
+        tx = tx.add(associated_token_account_ix)
     # Transfer the Token from the sender account to the associated token account
     spl_transfer_ix = spl_transfer(
         SPLTransferParams(
@@ -280,8 +292,9 @@ def burn(api_endpoint, contract_key, owner_key, private_key):
     # Start transaction
     tx = Transaction()
     # Find PDA for sender
-    token_pda_address = get_associated_token_address(owner_account, mint_account)
-    if client.get_account_info(token_pda_address)['result']['value'] is None: 
+    token_pda_address = get_associated_token_address(
+        owner_account, mint_account)
+    if client.get_account_info(token_pda_address)['result']['value'] is None:
         raise Exception
     # Burn token
     burn_ix = spl_burn(

--- a/metaplex/transactions.py
+++ b/metaplex/transactions.py
@@ -107,6 +107,30 @@ def topup(api_endpoint, sender_account, to, amount=None):
     tx = tx.add(transfer_ix)
     return tx, signers
 
+def update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, creators_addresses, creators_verified, creators_share):
+    """
+    Updates the json metadata for a given mint token id.
+    """
+    mint_account = PublicKey(mint_token_id)
+    signers = [source_account]
+
+    tx = Transaction()
+    update_metadata_data = update_metadata_instruction_data(
+        data['name'],
+        data['symbol'],
+        link,
+        creators_addresses,
+        creators_verified,
+        creators_share,
+    )
+    update_metadata_ix = update_metadata_instruction(
+        update_metadata_data,
+        source_account.public_key(),
+        mint_account,
+    )
+    tx = tx.add(update_metadata_ix) 
+    return tx, signers
+
 
 def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
     """


### PR DESCRIPTION
modified the code so it allows updating metadata and does not default the seller fee to 0.

```
update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share, fee,...):
```