### PR TITLE
added update metadata with parametrized seller fee

### DIFF
--- a/api/metaplex_api.py
+++ b/api/metaplex_api.py
@@ -2,7 +2,7 @@ import json
 from cryptography.fernet import Fernet
 import base58
 from solana.account import Account 
-from metaplex.transactions import deploy, topup, mint, send, burn
+from metaplex.transactions import deploy, topup, mint, send, burn, update_token_metadata
 from utils.execution_engine import execute
 
 class MetaplexAPI():
@@ -89,6 +89,25 @@ class MetaplexAPI():
         return json.dumps(resp)
         # except:
         #     return json.dumps({"status": 400})
+        
+    def update_token_metadata(self, api_endpoint, mint_token_id, link,  data, creators_addresses, creators_verified, creators_share,fee, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True, supply=1 ):
+            """
+            Updates the json metadata for a given mint token id.
+            """
+            tx, signers = update_token_metadata(api_endpoint, self.account, mint_token_id, link, data, fee, creators_addresses, creators_verified, creators_share)
+            resp = execute(
+                api_endpoint,
+                tx,
+                signers,
+                max_retries=max_retries,
+                skip_confirmation=skip_confirmation,
+                max_timeout=max_timeout,
+                target=target,
+                finalized=finalized,
+            )
+            resp["status"] = 200
+            return json.dumps(resp)
+
 
     def send(self, api_endpoint, contract_key, sender_key, dest_key, encrypted_private_key, max_retries=3, skip_confirmation=False, max_timeout=60, target=20, finalized=True):
         """

--- a/metaplex/metadata.py
+++ b/metaplex/metadata.py
@@ -47,7 +47,7 @@ def create_associated_token_account_instruction(associated_token_account, payer,
     ]
     return TransactionInstruction(keys=keys, program_id=ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID)
 
-def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
+def _get_data_buffer(name, symbol, uri, fee, creators, verified=None, share=None):
     if isinstance(share, list):
         assert(len(share) == len(creators))
     if isinstance(verified, list):
@@ -59,8 +59,9 @@ def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
         *list(symbol.encode()),
         len(uri),
         *list(uri.encode()),
-        0,
+        fee,
     ]
+ 
     byte_fmt = "<" 
     byte_fmt += "I" + "B"*len(name)
     byte_fmt += "I" + "B"*len(symbol)
@@ -87,8 +88,8 @@ def _get_data_buffer(name, symbol, uri, creators, verified=None, share=None):
     buffer = struct.pack(byte_fmt, *args)
     return buffer
     
-def create_metadata_instruction_data(name, symbol, creators):
-    _data = _get_data_buffer(name, symbol, " "*64, creators)
+def create_metadata_instruction_data(name, symbol, fee, creators):
+    _data = _get_data_buffer(name, symbol, " "*64, fee, creators)
     metadata_args_layout = cStruct(
         "data" / Bytes(len(_data)),
         "is_mutable" / Flag,
@@ -181,8 +182,8 @@ def get_metadata(client, mint_key):
     metadata = unpack_metadata_account(data)
     return metadata
 
-def update_metadata_instruction_data(name, symbol, uri, creators, verified, share):
-    _data = bytes([1]) + _get_data_buffer(name, symbol, uri, creators, verified, share) + bytes([0, 0])
+def update_metadata_instruction_data(name, symbol, uri, fee, creators, verified, share):
+    _data = bytes([1]) + _get_data_buffer(name, symbol, uri, fee, creators,  verified, share) + bytes([0, 0])
     instruction_layout = cStruct(
         "instruction_type" / Int8ul,
         "args" / Bytes(len(_data)),

--- a/metaplex/transactions.py
+++ b/metaplex/transactions.py
@@ -107,6 +107,31 @@ def topup(api_endpoint, sender_account, to, amount=None):
     tx = tx.add(transfer_ix)
     return tx, signers
 
+def update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, fee, creators_addresses, creators_verified, creators_share):
+    """
+    Updates the json metadata for a given mint token id.
+    """
+    mint_account = PublicKey(mint_token_id)
+    signers = [source_account]
+
+    tx = Transaction()
+    update_metadata_data = update_metadata_instruction_data(
+        data['name'],
+        data['symbol'],
+        link,
+        fee,
+        creators_addresses,        
+        creators_verified,
+        creators_share,
+    )
+    update_metadata_ix = update_metadata_instruction(
+        update_metadata_data,
+        source_account.public_key(),
+        mint_account,
+    )
+    tx = tx.add(update_metadata_ix) 
+    return tx, signers
+
 
 def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
     """
@@ -164,6 +189,7 @@ def mint(api_endpoint, source_account, contract_key, dest_key, link, supply=1):
         metadata['data']['symbol'],
         link,
         metadata['data']['creators'],
+        metadata['data']['fee'],
         metadata['data']['verified'],
         metadata['data']['share'],
     )


### PR DESCRIPTION
Added the ability to update metadata and set the seller fee (was set to 0 by default)

```
update_token_metadata(api_endpoint, source_account, mint_token_id, link, data, creators_addresses, creators_verified, creators_share, fee)
```